### PR TITLE
Handle power shell color scheme

### DIFF
--- a/Talk/Talk.fsproj
+++ b/Talk/Talk.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <!-- <Compile Include="Brainstorming/Infrastructure.fs" /> -->
@@ -25,6 +25,22 @@
     <Compile Include="UI/Menu.fs" />
     <Compile Include="UI/Helper.fs" />
     <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Argu" Version="5.2.0" />
+    <PackageReference Update="Expecto" Version="8.7.0" />
+    <PackageReference Update="FSharp.Core" Version="4.6.0" />
+    <PackageReference Update="Microsoft.NETCore.Platforms" Version="3.0.0-preview.18571.3" />
+    <PackageReference Update="Microsoft.NETCore.Targets" Version="3.0.0-preview.18571.3" />
+    <PackageReference Update="Mono.Cecil" Version="0.10.1" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.6.0-preview.18571.3" />
+    <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.6.0-preview.18571.3" />
+    <PackageReference Update="System.Reflection.Metadata" Version="1.7.0-preview.18571.3" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview.18571.3" />
+    <PackageReference Update="System.Security.AccessControl" Version="4.6.0-preview.18571.3" />
+    <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.6.0-preview.18571.3" />
+    <PackageReference Update="System.Security.Permissions" Version="4.6.0-preview.18571.3" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="4.6.0-preview.18571.3" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/Talk/UI/Menu.fs
+++ b/Talk/UI/Menu.fs
@@ -11,12 +11,25 @@ module Menu =
     footerAction actionParam
     printfn ""
 
+  let setCursorColor () =
+    let defaultColor () =
+      Console.ForegroundColor <- ConsoleColor.White
+      Console.BackgroundColor <- ConsoleColor.DarkBlue
+
+    let powershellColor () =
+      Console.ForegroundColor <- ConsoleColor.Black
+      Console.BackgroundColor <- ConsoleColor.Red
+
+    match Console.BackgroundColor with
+    | ConsoleColor.Black -> defaultColor ()
+    | ConsoleColor.DarkMagenta -> powershellColor ()
+    | _ -> defaultColor ()
+
   let printMenu selected executionTable =
     executionTable
     |> Seq.iteri (fun index (name:string,_) ->
         if index = selected then
-          Console.ForegroundColor <- ConsoleColor.White
-          Console.BackgroundColor <- ConsoleColor.DarkBlue
+          setCursorColor ()
 
         Console.WriteLine (sprintf " %i. %s" (index + 1) name)
         Console.ResetColor())

--- a/Videos/Videos.fsproj
+++ b/Videos/Videos.fsproj
@@ -2,10 +2,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Argu" Version="5.2.0" />
+    <PackageReference Update="Expecto" Version="8.7.0" />
+    <PackageReference Update="FSharp.Core" Version="4.6.0" />
+    <PackageReference Update="Microsoft.NETCore.Platforms" Version="2.2.0" />
+    <PackageReference Update="Mono.Cecil" Version="0.10.1" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="4.5.1" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Updated to netcore 2.2 and added a function to make the selected text more readable inside of powershell